### PR TITLE
Update input with new parts of the swagger spec

### DIFF
--- a/example/input.json
+++ b/example/input.json
@@ -1,4 +1,130 @@
 {
+  "paths": {
+    "/users": {
+      "get": {
+        "requestBody": {
+          "content": {
+            "application/json": {}
+          }
+        },
+
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          },
+
+          "401": {
+            "content": {}
+          },
+  
+          "500": {
+            "content": {}
+          }
+        }
+      }
+    },
+
+    "/users/{id}": {
+      "delete": {
+        "requestBody": {
+          "content": {
+            "application/json": {}
+          }
+        },
+
+        "responses": {
+          "204": {
+            "content": {}
+          },
+
+          "401": {
+            "content": {}
+          },
+  
+          "500": {
+            "content": {}
+          }
+        }
+      }
+    },
+
+    "/users/{id}/tags": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string"
+                  },
+                  "firstName": {
+                    "type": "string"
+                  },
+                  "lastName": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string"
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Tag"
+                    }
+                  },
+                  "address": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "username",
+                  "email"
+                ]
+              }
+            }
+          }
+        },
+
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          },
+  
+          "401": {
+            "content": {}
+          },
+
+          "500": {
+            "content": {}
+          }
+        }
+      }
+    }
+  },
+
   "components": {
     "schemas": {
       "User": {

--- a/example/input.json
+++ b/example/input.json
@@ -1,15 +1,15 @@
 {
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Acme Inc. REST API",
+    "version": "1.0.0"
+  },
   "paths": {
     "/users": {
       "get": {
-        "requestBody": {
-          "content": {
-            "application/json": {}
-          }
-        },
-
         "responses": {
           "200": {
+            "description": "",
             "content": {
               "application/json": {
                 "schema": {
@@ -23,10 +23,12 @@
           },
 
           "401": {
+            "description": "",
             "content": {}
           },
   
           "500": {
+            "description": "",
             "content": {}
           }
         }
@@ -34,23 +36,30 @@
     },
 
     "/users/{id}": {
-      "delete": {
-        "requestBody": {
-          "content": {
-            "application/json": {}
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
           }
-        },
-
+        }
+      ],
+      "delete": {
         "responses": {
           "204": {
+            "description": "",
             "content": {}
           },
 
           "401": {
+            "description": "",
             "content": {}
           },
   
           "500": {
+            "description": "",
             "content": {}
           }
         }
@@ -58,6 +67,16 @@
     },
 
     "/users/{id}/tags": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "requestBody": {
           "content": {
@@ -101,6 +120,7 @@
 
         "responses": {
           "201": {
+            "description": "",
             "content": {
               "application/json": {
                 "schema": {
@@ -114,10 +134,12 @@
           },
   
           "401": {
+            "description": "",
             "content": {}
           },
 
           "500": {
+            "description": "",
             "content": {}
           }
         }
@@ -131,8 +153,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "required": true
+            "type": "integer"
           },
           "username": {
             "type": "string"


### PR DESCRIPTION
In addition to just adding new pieces of the spec, mainly the "paths" object, I've also ran the input through swagger validation at https://editor.swagger.io/.

Some things turned out to be invalid such as:
- missing "openapi" or "swagger" field
- missing "version" field
- operations "get" & "delete" can't have request bodies
- "required: true" actually doesn't work on a schema field

Let's merge this now and incrementally add support for the newly added properties & fields.

Typegen still runs fine even on this input, it just doesn't do anything with the "paths" object yet.