### PR TITLE
Make typegen globally installable and executable

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require('fs')
 const { program } = require('commander')
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "description": "generate source-code types from swagger-specification file",
   "main": "index.js",
+  "bin": {
+    "typegen": "cli.js"
+  },
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watchAll",


### PR DESCRIPTION
To install globally, run `yarn link` in the root of typegen