### PR TITLE
Add support for aliases in refs

### DIFF
--- a/example/input.json
+++ b/example/input.json
@@ -176,7 +176,7 @@
           "tags": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Tag"
+              "$ref": "#/components/schemas/TagResponse"
             }
           },
           "badge": {
@@ -202,7 +202,8 @@
           "isActive"
         ]
       },
-      "Tag": {
+      "TagResponse": {
+        "title": "Tag",
         "type": "object",
         "properties": {
           "id": {

--- a/typescript/gen-type/gen-type.js
+++ b/typescript/gen-type/gen-type.js
@@ -16,13 +16,13 @@ function getTypeKeyword (typeDefinition) {
   return 'type'
 }
 
-function genType (typeKey, typeDefinition) {
+function genType (typeKey, typeDefinition, schemas) {
   const typeKeyword = getTypeKeyword(typeDefinition)
 
   const typeBody =
     typeKeyword === 'enum'
       ? genEnumBody(typeDefinition)
-      : genTypeBody(typeDefinition)
+      : genTypeBody(typeDefinition, schemas)
 
   const typeName = typeDefinition.title || typeKey
 

--- a/typescript/index.js
+++ b/typescript/index.js
@@ -5,7 +5,7 @@ const spread = require('../utils/spread')
 const genType = require('./gen-type')
 
 const genTypes = pipe(
-  Object.entries,
+  schemas => Object.entries(schemas).map(entries => [ ...entries, schemas ]),
   map(
     pipe(
       spread(genType),


### PR DESCRIPTION
This mr adds support for aliased refs for the use-case that a given Schema's name is aliased vie the title field e.g.:
```json
{
  "User": {
    "type": "object",
    "properties": {
      "tags": {
        "type": "array",
        "items": {
          "$ref": "#/components/schemas/TagResponse"
        }
      }
    }
  },
  "TagResponse": {
    "title": "Tag"
  }
}
```

resulting in

```typescript
export interface User {
  tags?: Tag[];
}
```
instead of


```typescript
export interface User {
  tags?: TagResponse[];
}
```